### PR TITLE
Fix for full memory buffer

### DIFF
--- a/GamutCompress.fuse
+++ b/GamutCompress.fuse
@@ -163,6 +163,7 @@ function Create()
   })
 end
 
+local lastreqtime = -2
 
 function Process(req)
   local src = InImage:GetValue(req)
@@ -170,7 +171,12 @@ function Process(req)
 
   if not req:IsPreCalc() then
     local node = DVIPComputeNode(req, "SolidKernel", SolidKernel, "SolidParams", SolidParams)
-    local params = node:GetParamBlock(SolidParams)
+    
+    local params
+    if (lastreqtime ~= req.Time - 1) then
+        local params = node:GetParamBlock(SolidParams)
+    end
+    lastreqtime = req.Time
 
     params.threshold_c = InThresholdR:GetValue(req).Value
     params.threshold_m = InThresholdG:GetValue(req).Value

--- a/GamutCompress.fuse
+++ b/GamutCompress.fuse
@@ -174,7 +174,7 @@ function Process(req)
     
     local params
     if (lastreqtime ~= req.Time - 1) then
-        local params = node:GetParamBlock(SolidParams)
+        params = node:GetParamBlock(SolidParams)
     end
     lastreqtime = req.Time
 


### PR DESCRIPTION
For some reason when the memory buffer is full GetParamBlock can't be read and the comp craches.
Adding an if check for an external local parameter solved this (for some reason).